### PR TITLE
Add regional versions

### DIFF
--- a/functions/src/guardianBriefingFunction/guardianBriefingFunction.ts
+++ b/functions/src/guardianBriefingFunction/guardianBriefingFunction.ts
@@ -7,6 +7,7 @@ import {
 } from 'actions-on-google';
 import { getBriefingContent } from './api';
 import { buildListFromArticles } from './richResponseBuilder';
+import { Locale, getLocale } from '../localeUtils';
 
 const appConfig = config();
 
@@ -15,7 +16,8 @@ const app = dialogflow<{}, {}>({
 });
 
 const response = (conv: DialogflowConversation) => {
-  const url: string = appConfig.briefing.content;
+  const locale: Locale = getLocale(conv.user.locale);
+  const url: string = getURL(locale);
   return getBriefingContent(url).then(briefing => {
     const data = new SimpleResponse({
       speech: ssmlGen(briefing.audioFileLocation),
@@ -32,6 +34,17 @@ const response = (conv: DialogflowConversation) => {
       conv.close(data);
     }
   });
+};
+
+const getURL = (locale: Locale) => {
+  switch (locale) {
+    case Locale.GB:
+      return appConfig.briefing.ukcontent;
+    case Locale.AU:
+      return appConfig.briefing.aucontent;
+    case Locale.US:
+      return appConfig.briefing.uscontent;
+  }
 };
 
 const canDisplayCarousel = (conv: DialogflowConversation) => {

--- a/functions/src/localeUtils.ts
+++ b/functions/src/localeUtils.ts
@@ -1,0 +1,21 @@
+const getLocale = (locale: any) => {
+  const supportedLocales: { [key: string]: Locale } = {
+    'en-AU': Locale.AU,
+    'en-CA': Locale.US,
+    'en-GB': Locale.GB,
+    'en-IN': Locale.GB,
+    'en-SG': Locale.GB,
+    'en-US': Locale.US,
+  };
+
+  const l: Locale = supportedLocales[locale];
+  return typeof l === 'undefined' ? Locale.GB : l;
+};
+
+enum Locale {
+  AU = 'en-AU',
+  GB = 'en-GB',
+  US = 'en-US',
+}
+
+export { Locale, getLocale };

--- a/functions/src/snapshotterFunction/models.ts
+++ b/functions/src/snapshotterFunction/models.ts
@@ -1,7 +1,0 @@
-enum Locale {
-  AU = 'en-AU',
-  GB = 'en-GB',
-  US = 'en-US',
-}
-
-export { Locale };

--- a/functions/src/snapshotterFunction/snapshotterFunction.ts
+++ b/functions/src/snapshotterFunction/snapshotterFunction.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import { Storage } from '@google-cloud/storage';
 import { region, config } from 'firebase-functions';
 import { Response } from 'express';
-import { Locale } from './models';
+import { Locale, getLocale } from '../localeUtils';
 
 const appConfig = config();
 
@@ -28,20 +28,6 @@ const generateBriefing = region('europe-west1').https.onRequest(
       });
   }
 );
-
-const getLocale = (locale: any) => {
-  const supportedLocales: { [key: string]: Locale } = {
-    'en-AU': Locale.AU,
-    'en-CA': Locale.US,
-    'en-GB': Locale.GB,
-    'en-IN': Locale.GB,
-    'en-SG': Locale.GB,
-    'en-US': Locale.US,
-  };
-
-  const l: Locale = supportedLocales[locale];
-  return typeof l === 'undefined' ? Locale.GB : l;
-};
 
 const buildURL = (locale: Locale) => {
   switch (locale) {


### PR DESCRIPTION
This required a change to both cloud functions

### Snapshotter Function 
The endpoint now takes a locale param (if no param is provided then GB is used). This parameter is used when calling the Structured News API and is also added to the snapshots saved to Google Cloud

### Guardian Briefing Function
The function now gets the user's locale and gets a different version of the briefing depending on the user's locale.

This change has also added additional environment parameters.