### PR TITLE
Account for a longer briefing that needs to be split over 2 files.

### DIFF
--- a/functions/src/guardianBriefingFunction/guardianBriefingFunction.ts
+++ b/functions/src/guardianBriefingFunction/guardianBriefingFunction.ts
@@ -54,8 +54,22 @@ const canDisplayCarousel = (conv: DialogflowConversation) => {
   );
 };
 
-const ssmlGen = (audioLink: string) => {
-  return "<speak><audio src='" + audioLink + "'/></speak>";
+const ssmlGen = (audioLinks: [string, string] | [string]): string => {
+  if (audioLinks.length < 2) {
+    return "<speak><audio src='" + audioLinks + "'/></speak>";
+  } else {
+    return `
+      <speak>
+        <par>
+          <media xml:id='part1'>
+            <audio src='${audioLinks[0]}'/>
+          </media>
+          <media xml:id='part2' begin='part1.end-1.0s'>
+            <audio src='${audioLinks[1]}'/>
+          </media>
+        </par>
+      </speak>`;
+  }
 };
 
 app.intent('welcome_intent', response);

--- a/functions/src/guardianBriefingFunction/models.ts
+++ b/functions/src/guardianBriefingFunction/models.ts
@@ -1,6 +1,5 @@
 interface MorningBriefing {
-  ssml: string;
-  audioFileLocation: string;
+  audioFileLocation: [string] | [string, string];
   content: Article[];
 }
 


### PR DESCRIPTION
Extended the length of the weekday AM briefing https://github.com/guardian/structured-news-api/pull/47

This has changed the shape of the API response coming from SNAPI. Now it returns a tuple of either length 1 or 2.