### PR TITLE
Do not keep record of previous versions of the Guardian Briefing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There is a [zip file](Guardian-Briefin.zip) for restoring the Dialogflow part of
 
 ## Snapshotter Function:
 
-This function runs every 5 minutes using Google Cloud Scheduler. It calls the [structured-news-api](https://github.com/guardian/structured-news-api) and uploads the JSON response to a Google Cloud Storage Bucket. This is so the Guardian Briefing Function can use this cached version of the SNAPI (structured news API) response. It also uploads a timestamped copy to a snapshot bucket so that there is a record of previous briefings.
+This function runs every 5 minutes using Google Cloud Scheduler. It calls the [structured-news-api](https://github.com/guardian/structured-news-api) and uploads the JSON response to a Google Cloud Storage Bucket. This is so the Guardian Briefing Function can use this cached version of the SNAPI (structured news API) response.
 
 This is good because:
 

--- a/functions/src/snapshotterFunction/snapshotterFunction.ts
+++ b/functions/src/snapshotterFunction/snapshotterFunction.ts
@@ -9,7 +9,6 @@ const appConfig = config();
 
 const googleCloudStorage = new Storage();
 const cacheBucketName = 'gu-briefing-cache';
-const snapshotBucketName = 'gu-briefing-snapshots';
 const fileLocation = '/tmp/briefing-content.json';
 
 const generateBriefing = region('europe-west1').https.onRequest(
@@ -68,20 +67,11 @@ const createAndUploadFile = (
 };
 
 const googleUpload = (locale: Locale) => {
-  return googleCloudStorage
-    .bucket(cacheBucketName)
-    .upload(fileLocation, {
-      destination: getFileName(locale),
-      public: true,
-      metadata: { cacheControl: 'no-cache' },
-    })
-    .then(_ => {
-      return googleCloudStorage
-        .bucket(snapshotBucketName)
-        .upload(fileLocation, {
-          destination: `${new Date().toString()}-${getFileName(locale)}`,
-        });
-    });
+  return googleCloudStorage.bucket(cacheBucketName).upload(fileLocation, {
+    destination: getFileName(locale),
+    public: true,
+    metadata: { cacheControl: 'no-cache' },
+  });
 };
 
 const getFileName = (locale: Locale) => {


### PR DESCRIPTION
During active development we were taking snapshots of the Guardian Briefing so that we could analyse the quality. With active development coming to a close for now I'm removing this functionality as it generates a lot of files.